### PR TITLE
New Stimulus controller Maker command

### DIFF
--- a/src/Maker/MakeStimulusController.php
+++ b/src/Maker/MakeStimulusController.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+/**
+ * @author Abdelilah Jabri <jbrabdelilah@gmail.com>
+ *
+ * @internal
+ */
+final class MakeStimulusController extends AbstractMaker
+{
+    public const SUFFIX = '_controller.js';
+
+    public const PATH = 'assets/controllers/';
+
+    public static function getCommandName(): string
+    {
+        return 'make:stimulus-controller';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new Stimulus controller';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->addArgument('name', InputArgument::OPTIONAL, 'The name of the stimulus controller (e.g. <fg=yellow>hello</>)')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeStimulusController.txt'));
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $controllerName = $input->getArgument('name');
+        $fileName = $controllerName.self::SUFFIX;
+        $filePath = self::PATH.$fileName;
+
+        $generator->generateFile(
+            $filePath,
+            'stimulus/Controller.tpl.php'
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text([
+            'Next:',
+            sprintf('- Open <info>%s</info> and add the code you need', $filePath),
+            sprintf('- Use the controller in your template as <info><div data-controller="%s"></div></info>', $controllerName),
+            'Find the documentation at <fg=yellow>https://github.com/symfony/stimulus-bridge</>',
+        ]);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies->addClassDependency(
+            WebpackEncoreBundle::class,
+            'webpack-encore-bundle'
+        );
+    }
+}

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -129,5 +129,9 @@
                 <argument>%kernel.project_dir%</argument>
                 <tag name="maker.command" />
             </service>
+
+            <service id="maker.maker.make_stimulus_controller" class="Symfony\Bundle\MakerBundle\Maker\MakeStimulusController">
+                <tag name="maker.command" />
+            </service>
         </services>
 </container>

--- a/src/Resources/help/MakeStimulusController.txt
+++ b/src/Resources/help/MakeStimulusController.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates new Stimulus Controller.
+
+<info>php %command.full_name% hello</info>
+
+If the argument is missing, the command will ask for the controller name interactively.

--- a/src/Resources/skeleton/stimulus/Controller.tpl.php
+++ b/src/Resources/skeleton/stimulus/Controller.tpl.php
@@ -1,0 +1,7 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    connect() {
+        // Here: update the connected element
+    }
+}

--- a/tests/Maker/MakeStimulusControllerTest.php
+++ b/tests/Maker/MakeStimulusControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeStimulusController;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+
+class MakeStimulusControllerTest extends MakerTestCase
+{
+    protected function getMakerClass(): string
+    {
+        return MakeStimulusController::class;
+    }
+
+    public function getTestDetails()
+    {
+        yield 'it_generates_stimulus_controller' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // controller name
+                        'custom',
+                    ]);
+
+                $this->assertFileExists($runner->getPath('assets/controllers/custom_controller.js'));
+            }),
+        ];
+    }
+}


### PR DESCRIPTION
New Command to generate Stimulus Controller

![Stimulus controller Maker command](https://user-images.githubusercontent.com/42073961/154850651-abfffcca-e580-4fc4-a728-19b9128864a0.png)

**test_controller.js**
```
import { Controller } from '@hotwired/stimulus';

export default class extends Controller {
    connect() {
        // Here: update the connected element
    }
}
```
Tickets #809

**What's next?**

- [ ] Give the option to generate the related Twig template.
- [ ] Generate Stimulus Controller in a subdirectory.

